### PR TITLE
added TRQ extention

### DIFF
--- a/src/nomad_hysprint/parsers/hysprint_measurement_parser.py
+++ b/src/nomad_hysprint/parsers/hysprint_measurement_parser.py
@@ -137,7 +137,7 @@ class HySprintParser(MatchingParser):
             entry = HySprint_JVmeasurement()
         if mainfile_split[-1] == 'txt' and measurment_type == 'spv':
             entry = HySprint_trSPVmeasurement()
-        if mainfile_split[-1] == 'txt' or mainfile_split[-1] == 'TRQ' and measurment_type == 'eqe':
+        if (mainfile_split[-1] == 'txt' or mainfile_split[-1] == 'TRQ') and measurment_type == 'eqe':
             entry = HySprint_EQEmeasurement()
         if mainfile_split[-1] in ['tif', 'tiff'] and measurment_type.lower() == 'sem':
             entry = HySprint_SEM()

--- a/src/nomad_hysprint/parsers/hysprint_measurement_parser.py
+++ b/src/nomad_hysprint/parsers/hysprint_measurement_parser.py
@@ -137,7 +137,7 @@ class HySprintParser(MatchingParser):
             entry = HySprint_JVmeasurement()
         if mainfile_split[-1] == 'txt' and measurment_type == 'spv':
             entry = HySprint_trSPVmeasurement()
-        if mainfile_split[-1] == 'txt' and measurment_type == 'eqe':
+        if mainfile_split[-1] == 'txt' or mainfile_split[-1] == 'TRQ' and measurment_type == 'eqe':
             entry = HySprint_EQEmeasurement()
         if mainfile_split[-1] in ['tif', 'tiff'] and measurment_type.lower() == 'sem':
             entry = HySprint_SEM()


### PR DESCRIPTION
During a visit in Hysprint, there was a mention that sometimes EQE measurement files were saved with ending TRQ instead of txt. I added a line at the hysprint_measurement_parser for recognizing the TRQ ending and parsing the file. The parsing is exactly the same. Checked also at the local gui and measurement graph looks fine. 

I open a pull request, in case we want to add this function. Feel free to reject/delete branch if there is a reason not to add it. 

