### PR TITLE
Datetime test

### DIFF
--- a/src/nomad_hysprint/parsers/hysprint_batch_parser.py
+++ b/src/nomad_hysprint/parsers/hysprint_batch_parser.py
@@ -119,6 +119,7 @@ class HySprintExperimentParser(MatchingParser):
         archives = [map_batch(sample_ids, batch_id, upload_id, HySprint_Batch)]
         substrates = []
         substrates_col = [
+            'Date',
             'Sample dimension',
             'Sample area [cm^2]',
             'Pixel area [cm^2]',

--- a/src/nomad_hysprint/parsers/hysprint_batch_parser.py
+++ b/src/nomad_hysprint/parsers/hysprint_batch_parser.py
@@ -119,7 +119,6 @@ class HySprintExperimentParser(MatchingParser):
         archives = [map_batch(sample_ids, batch_id, upload_id, HySprint_Batch)]
         substrates = []
         substrates_col = [
-            'Date',
             'Sample dimension',
             'Sample area [cm^2]',
             'Pixel area [cm^2]',

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -592,7 +592,7 @@ def test_hy_batch_parser_new_cols(monkeypatch):  # noqa: PLR0915
 
 def test_hy_batch_parser_ink_recycling(monkeypatch):
     """Test the ink recycling parser integration"""
-    
+
     file = '20250616_ink_recycling_test.xlsx'
     file_name = os.path.join('tests', 'data', file)
     file_archive = parse(file_name)[0]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -252,7 +252,6 @@ def test_hy_batch_parser_new_cols(monkeypatch):  # noqa: PLR0915
                 assert m.data.description == '1000 rpm'
                 assert m.data.number_of_junctions == 1
         elif 'Substrate' in str(type(m.data)):
-            assert m.data.datetime.isoformat() == '2025-02-26T00:00:00+00:00'
             assert m.data.solar_cell_area == 0.16 * ureg('cm**2')
             assert m.data.pixel_area == 0.16 * ureg('cm**2')
             assert m.data.number_of_pixels == 6
@@ -593,7 +592,7 @@ def test_hy_batch_parser_new_cols(monkeypatch):  # noqa: PLR0915
 
 def test_hy_batch_parser_ink_recycling(monkeypatch):
     """Test the ink recycling parser integration"""
-
+    delete_json()
     file = '20250616_ink_recycling_test.xlsx'
     file_name = os.path.join('tests', 'data', file)
     file_archive = parse(file_name)[0]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -592,7 +592,7 @@ def test_hy_batch_parser_new_cols(monkeypatch):  # noqa: PLR0915
 
 def test_hy_batch_parser_ink_recycling(monkeypatch):
     """Test the ink recycling parser integration"""
-    delete_json()
+    
     file = '20250616_ink_recycling_test.xlsx'
     file_name = os.path.join('tests', 'data', file)
     file_archive = parse(file_name)[0]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -248,9 +248,11 @@ def test_hy_batch_parser_new_cols(monkeypatch):  # noqa: PLR0915
         if 'Sample' in str(type(m.data)) or 'Batch' in str(type(m.data)):
             count_samples_batches += 1
             if 'Sample' in str(type(m.data)):
+                assert m.data.datetime.isoformat() == '2025-02-26T00:00:00+00:00'
                 assert m.data.description == '1000 rpm'
                 assert m.data.number_of_junctions == 1
         elif 'Substrate' in str(type(m.data)):
+            assert m.data.datetime.isoformat() == '2025-02-26T00:00:00+00:00'
             assert m.data.solar_cell_area == 0.16 * ureg('cm**2')
             assert m.data.pixel_area == 0.16 * ureg('cm**2')
             assert m.data.number_of_pixels == 6


### PR DESCRIPTION
In hysprint, only the sample maps the datetime from the excel sheet 
(substrate datetime interfered with the ink recycling workflow that does not involve substrates)